### PR TITLE
Allow for specifying transport in setupSSLContext()

### DIFF
--- a/Sources/mbedTLS/Model/SSLTransport.swift
+++ b/Sources/mbedTLS/Model/SSLTransport.swift
@@ -1,0 +1,13 @@
+//
+//  SSLTransport.swift
+//  
+//
+//  Created by Brian Gomberg on 7/10/23.
+//
+
+import Foundation
+
+public enum SSLTransport: Int32 {
+    case stream = 0
+    case datagram = 1
+}

--- a/Sources/mbedTLS/mbedTLS.swift
+++ b/Sources/mbedTLS/mbedTLS.swift
@@ -92,8 +92,8 @@ public class mbedTLS {
         }
     }
 
-    public static func setupSSLContext() throws {
-        let configureSSL = mbedtls_ssl_config_defaults(&sslConfig, MBEDTLS_SSL_IS_CLIENT, MBEDTLS_SSL_TRANSPORT_STREAM, MBEDTLS_SSL_PRESET_DEFAULT)
+    public static func setupSSLContext(transport: SSLTransport = .stream) throws {
+        let configureSSL = mbedtls_ssl_config_defaults(&sslConfig, MBEDTLS_SSL_IS_CLIENT, transport.rawValue, MBEDTLS_SSL_PRESET_DEFAULT)
         if configureSSL != 0 { throw mbedTLSError.sslConfiguration }
 
         mbedtls_ssl_conf_rng(&sslConfig, mbedtls_ctr_drbg_random, &counterRandomByteGenerator)


### PR DESCRIPTION
This allows for supporting DTLS without breaking any backwards compatibility.